### PR TITLE
WIP: 60

### DIFF
--- a/060/main.py
+++ b/060/main.py
@@ -1,0 +1,90 @@
+from collections import OrderedDict
+from functools import reduce, lru_cache
+import itertools
+
+# A simple implementation of the Sieve of Eratosthenes
+# n is inclusive
+def primes_up_to(n):
+    is_prime = OrderedDict((n, True) for n in range(2, n+1))
+    i = 2
+    while i <= n ** 0.5:
+        for j in range(i*2, n+1, i):
+            is_prime[j] = False
+        # increment
+        i += 1
+        while not is_prime[i]:
+            i += 1
+    result = []
+    for n in is_prime:
+        if is_prime[n]:
+            result.append(n)
+    return result
+
+cap = 10000
+primes = primes_up_to(cap)
+print('ready')
+
+def main():
+    example = {3, 7, 109, 673}
+    # what = [3, 11, 17, 53]
+    # print(ok([3, 7, 109, 673]))
+    # return
+    for i, idxs in enumerate(combos(3)):
+        selected = [primes[idx] for idx in idxs]
+
+        # if i % 100000 == 0:
+        #     print(i // 1000, idxs[-1], primes[idxs[-1]])
+
+        if ok(selected):
+            print(selected)
+            return
+            # print(selected, '***' if set(selected) <= example else '')
+
+        # if selected == [3, 7, 109, 673]:
+        #     print(i)
+        #     return
+
+def ok(prime_set):
+    for a, b in itertools.permutations(prime_set, 2):
+        concatenation = intcat(a, b)
+        # print(concatenation)
+        if not is_prime(concatenation):
+            return False
+    return True
+
+def combos(n):
+    for z in itertools.count(start = n - 1):
+        for abc in itertools.combinations(range(0, z), n - 1):
+            yield (*abc, z)
+
+def intcat(a, b):
+    result = a * pow10(count_digits(b)) + b
+    # expected = int(str(a) + str(b))
+    # assert expected == result, (expected, result, a, b)
+    return result
+
+@lru_cache(maxsize=None)
+def pow10(n):
+    return 10 ** n
+
+def count_digits(n):
+    length = 0
+    while n > 0:
+        length += 1
+        n //= 10
+    return length
+
+
+
+@lru_cache(maxsize=None)
+def is_prime(n):
+    # if n <= cap:
+    #     return n in primes
+    if n <= 1:
+        return False
+    for m in range(2, n):
+        if n % m == 0:
+            return False
+    return True
+
+main()


### PR DESCRIPTION
Brute force works for a set of four primes (the example), but too slow for a set of five primes (the question).

Can we use a brute force search for sets of n primes to find a set of n+1 primes? I think this should work. For n = 3 (to find the example set of four primes by brute force search for sets of three primes), it would look something like this:

The answer will be [3, 7, 109, 673].

The interesting steps are marked with asterisks (but of course we don't know they're interesting til we find the answer).

When we see `[3, 7, 673]`, we check if we've seen 3 and 7 in a triple before. We have -- with 109. So `3, 7, 109, 673` is a potential quad.

```
[3, 37, 67] 
[7, 19, 97] 
[3, 7, 109] ***
[19, 31, 181] 
[3, 137, 191] 
...
[139, 547, 661] 
[439, 541, 661] 
[439, 613, 661] 
[3, 7, 673] ***
[3, 109, 673] ***
[3, 499, 673] 
[3, 613, 673] 
[7, 109, 673] ***
```